### PR TITLE
Changed POM to use individual activemq libraries instead of activemq-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,10 +160,19 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.activemq</groupId>
-			<artifactId>activemq-all</artifactId>
-			<version>${activemq.version}</version>
+			<artifactId>activemq-client</artifactId>
+			<version>5.12.1</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-broker</artifactId>
+			<version>5.12.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.activemq</groupId>
+			<artifactId>activemq-kahadb-store</artifactId>
+			<version>5.12.1</version>
+		</dependency>
 		<!-- for testing -->
 		<dependency>
 			<groupId>org.mule.tests</groupId>
@@ -171,7 +180,7 @@
 			<version>${mule.version}</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<!-- added automatically -->
 		<dependency>
 			<groupId>org.mule.modules</groupId>


### PR DESCRIPTION
…all, which for 5.12.1 does not work because of classpath conflict with StaticLoggerBinder.class
